### PR TITLE
Planar hand example works well with the new IrsLqr API.

### DIFF
--- a/examples/planar_hand/planar_hand_setup.py
+++ b/examples/planar_hand/planar_hand_setup.py
@@ -25,12 +25,12 @@ contact_detection_tolerance = 10.0
 gradient_lstsq_tolerance = 1e-3
 
 # gradient mode
-gradient_mode = "exact"
+gradient_mode = "first_order"
 decouple_AB = True
 
 # num_workers
 use_workers = True
-num_workers = 30
+num_workers = 20
 task_stride = 1
-num_iters = 30
+num_iters = 20
 num_samples = 100

--- a/examples/planar_hand/run_planar_hand.py
+++ b/examples/planar_hand/run_planar_hand.py
@@ -19,7 +19,7 @@ from irs_lqr.irs_lqr_quasistatic import (
 from planar_hand_setup import *
 
 #%% sim setup
-T = int(round(6 / h))  # num of time steps to simulate forward.
+T = int(round(3 / h))  # num of time steps to simulate forward.
 duration = T * h
 sim_params = QuasistaticSimParameters(
     gravity=gravity,
@@ -107,7 +107,7 @@ for i in range(T):
     print('Dq_nextDqa_cmd error cpp vs python',
           np.linalg.norm(Dq_nextDqa_cmd - Dq_nextDqa_cmd_cpp))
     u_traj_0[i] = u
-    x_next = x
+    x = x_next
     q_dict_traj.append(q_dynamics.get_q_dict_from_x(x))
 
 
@@ -115,18 +115,17 @@ q_sim_py.animate_system_trajectory(h, q_dict_traj)
 
 
 #%%
-
 params = IrsLqrQuasistaticParameters()
 params.Q_dict = {
-    idx_u: np.array([10, 10, 0.0]),
-    idx_a_l: np.array([0.0, 0.0]),
-    idx_a_r: np.array([0.0, 0.0])}
+    idx_u: np.array([10, 10, 1e-3]),
+    idx_a_l: np.array([1e-3, 1e-3]),
+    idx_a_r: np.array([1e-3, 1e-3])}
 params.Qd_dict = {model: Q_i * 100 for model, Q_i in params.Q_dict.items()}
 params.R_dict = {
-    idx_a_l: 1e2 * np.array([1, 1]),
-    idx_a_r: 1e2 * np.array([1, 1])}
+    idx_a_l: 5 * np.array([1, 1]),
+    idx_a_r: 5 * np.array([1, 1])}
 
-xd_dict = {idx_u: q_u0 + np.array([0.3, 0.0, 0]),
+xd_dict = {idx_u: q_u0 + np.array([0.3, -0.1, 0]),
            idx_a_l: qa_l_knots[0],
            idx_a_r: qa_r_knots[0]}
 xd = q_dynamics.get_x_from_q_dict(xd_dict)
@@ -137,11 +136,13 @@ params.x_trj_d = x_trj_d
 params.u_trj_0 = u_traj_0
 params.T = T
 
-params.u_bounds_rel = np.array([
+params.u_bounds_abs = np.array([
     -np.ones(dim_u) * 0.5 * h, np.ones(dim_u) * 0.5 * h])
 
+
 def sampling(u_initial, iter):
-    return u_initial ** (0.5 * iter)
+    return u_initial / (iter ** 0.8)
+
 
 params.sampling = sampling
 params.std_u_initial = np.ones(dim_u) * 0.3

--- a/irs_lqr/irs_lqr_first_order.py
+++ b/irs_lqr/irs_lqr_first_order.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from irs_lqr.irs_lqr import IrsLqr
 
+
 class IrsLqrFirstOrder(IrsLqr):
     def __init__(self, system, params, sampling):
         super().__init__(system, params)
@@ -46,8 +47,8 @@ class IrsLqrFirstOrder(IrsLqr):
             # Average across batch dim to get estimates.
             ABhat = np.mean(AB_batch, axis=0)
 
-            At[t] = ABhat[:,0:self.dim_x]
-            Bt[t] = ABhat[:,self.dim_x:self.dim_x+self.dim_u]
+            At[t] = ABhat[:, 0:self.dim_x]
+            Bt[t] = ABhat[:, self.dim_x:self.dim_x + self.dim_u]
             ct[t] = self.system.dynamics(x_trj[t], u_trj[t]) - At[t].dot(
                 x_trj[t]) - Bt[t].dot(u_trj[t])
         return At, Bt, ct

--- a/irs_lqr/irs_lqr_quasistatic.py
+++ b/irs_lqr/irs_lqr_quasistatic.py
@@ -1,5 +1,5 @@
 from typing import Dict
-import time 
+import time
 
 from pydrake.all import ModelInstanceIndex
 
@@ -7,6 +7,7 @@ from irs_lqr.quasistatic_dynamics import QuasistaticDynamics
 from irs_lqr.tv_lqr import solve_tvlqr, get_solver
 
 from zmq_parallel_cmp.array_io import *
+
 
 class IrsLqrQuasistaticParameters:
     def __init__(self):
@@ -27,7 +28,7 @@ class IrsLqrQuasistaticParameters:
 
         # Necessary arguments related to sampling.
         self.sampling = None
-        self.std_u_initial = None        
+        self.std_u_initial = None
         self.num_samples = 100
 
         # Arguments related to various options.
@@ -39,9 +40,10 @@ class IrsLqrQuasistaticParameters:
         self.task_stride = 1
         self.publish_every_iteration = True
 
+
 class IrsLqrQuasistatic:
-    def __init__(self, q_dynamics: QuasistaticDynamics, 
-        params: IrsLqrQuasistaticParameters):
+    def __init__(self, q_dynamics: QuasistaticDynamics,
+                 params: IrsLqrQuasistaticParameters):
         """
 
         Arguments are similar to those of SqpLsImplicit.
@@ -73,7 +75,7 @@ class IrsLqrQuasistatic:
         self.u_bounds_rel = params.u_bounds_rel
         self.indices_u_into_x = q_dynamics.get_u_indices_into_x()
 
-        self.decouple_AB = params.decouple_AB 
+        self.decouple_AB = params.decouple_AB
         self.use_workers = params.use_workers
         self.gradient_mode = params.gradient_mode
         self.task_stride = params.task_stride
@@ -206,7 +208,7 @@ class IrsLqrQuasistatic:
 
         # Compute ABhat.
         ABhat_list = self.q_dynamics.calc_AB_batch(
-            x_trj[:-1,:], u_trj, n_samples=self.num_samples, std_u=std_u,
+            x_trj[:-1, :], u_trj, n_samples=self.num_samples, std_u=std_u,
             mode=self.gradient_mode
         )
 
@@ -290,7 +292,7 @@ class IrsLqrQuasistatic:
         if self.use_workers:
             At, Bt, ct = self.get_TV_matrices_batch(x_trj, u_trj)
         else:
-            At, Bt, ct = self.get_TV_matrices(x_trj, u_trj) 
+            At, Bt, ct = self.get_TV_matrices(x_trj, u_trj)
 
         x_trj_new = np.zeros(x_trj.shape)
         x_trj_new[0, :] = x_trj[0, :]
@@ -326,16 +328,16 @@ class IrsLqrQuasistatic:
                 ct[t:self.T], self.Q, self.Qd,
                 self.R, x_trj_new[t, :],
                 self.x_trj_d[t:],
-                solver = self.solver,
+                solver=self.solver,
                 indices_u_into_x=self.indices_u_into_x,
-                x_bound_abs = x_bounds_abs[:, t:, :] if (
-                    self.x_bounds_abs is not None) else None,
-                u_bound_abs = u_bounds_abs[:, t:, :] if (
-                    self.u_bounds_abs is not None) else None,                
-                x_bound_rel = x_bounds_rel[:, t:, :] if (
-                    self.x_bounds_rel is not None) else None,
-                u_bound_rel = u_bounds_rel[:, t:, :] if (
-                    self.u_bounds_rel is not None) else None,
+                x_bound_abs=x_bounds_abs[:, t:, :] if (
+                        self.x_bounds_abs is not None) else None,
+                u_bound_abs=u_bounds_abs[:, t:, :] if (
+                        self.u_bounds_abs is not None) else None,
+                x_bound_rel=x_bounds_rel[:, t:, :] if (
+                        self.x_bounds_rel is not None) else None,
+                u_bound_rel=u_bounds_rel[:, t:, :] if (
+                        self.u_bounds_rel is not None) else None,
                 xinit=None,
                 uinit=None)
             u_trj_new[t, :] = u_star[0]

--- a/irs_lqr/quasistatic_dynamics.py
+++ b/irs_lqr/quasistatic_dynamics.py
@@ -145,7 +145,7 @@ class QuasistaticDynamics(DynamicalSystem):
         return self.get_x_from_q_dict(q_next_dict)
 
     def dynamics(self, x: np.ndarray, u: np.ndarray, requires_grad: bool = False,
-                 grad_from_active_constraints: bool = False):
+                 grad_from_active_constraints: bool = True):
         """
         :param x: the position vector of self.q_sim.plant.
         :param u: commanded positions of models in

--- a/irs_lqr/tv_lqr.py
+++ b/irs_lqr/tv_lqr.py
@@ -107,8 +107,7 @@ def solve_tvlqr(At, Bt, ct, Q, Qd, R, x0, x_trj_d, solver, indices_u_into_x=None
             prog.AddQuadraticCost(du.dot(R).dot(du))
 
         else:
-            prog.AddQuadraticCost(R, np.zeros(n_u), ut[t,:])
-
+            prog.AddQuadraticCost(R, np.zeros(n_u), ut[t, :])
 
         # Add constraints.
         if x_bound_abs is not None:
@@ -129,7 +128,7 @@ def solve_tvlqr(At, Bt, ct, Q, Qd, R, x0, x_trj_d, solver, indices_u_into_x=None
 
     # Add final constraint.
     prog.AddQuadraticErrorCost(Qd, x_trj_d[T, :], xt[T, :])
-    
+
     if x_bound_abs is not None:
         prog.AddBoundingBoxConstraint(
             x_bound_abs[0, T], x_bound_abs[1, T], xt[T, :])


### PR DESCRIPTION
IrsLqr now computes dynamics gradient using only the active constraints by default. Planar hand is the first example to demonstrate that this works well with the new IrsLqr API since the last refactor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hjsuh94/irs_lqr/15)
<!-- Reviewable:end -->
